### PR TITLE
fix bad allocation [corrupted size vs. prev_size]

### DIFF
--- a/include/util.h
+++ b/include/util.h
@@ -1,24 +1,22 @@
 #include <string.h>
 #include <stdlib.h>
 
+
 char * salloc(char* string){
-	int i;
-	for(  i = 0 ; string[i] != '\0' ; i++ ){}
-	char* a = (char *)malloc(sizeof(char)*(i+1));
+	char* a = (char *)malloc((sizeof(char)*(strlen(string) + 1)));
 	if(a == NULL){
 		perror("Fatal error in malloc...\n");
 		exit(0);
 	}
-	for(;i>=0;i--){
-		a[i] = string[i];
-	}
+	strcpy(a, string);
 	return a;
 }
 
 char * strcat2(char* strng1, char* strng2){
-	char* t1 = salloc(strng1);
-	char* t2 = salloc(strng2);
-	strcat(t1,"/");
-	strcat(t1,t2);
-	return t1;
+
+	char tmp[(strlen(strng1) + strlen(strng2) + 2)];
+	sprintf(tmp, "%s/%s", strng1, strng2);
+	char * t = salloc(tmp);
+
+	return t;
 }


### PR DESCRIPTION
Continua da qui.
Pur eseguendo da cli 
$ a.out /home/ale
senza '/' ad un certo punto il processo trova comunque path invalidi, questo fa terminare la scansione del file system.
Dovresti stampare a schermo una serie di messaggi per debug su questa situazione e andare avanti nella scansione